### PR TITLE
fix issue #1 - handle colon in decode()

### DIFF
--- a/basicauth.py
+++ b/basicauth.py
@@ -27,7 +27,7 @@ def decode(encoded_str):
     # directly.
     if len(split) == 1:
         try:
-            username, password = b64decode(split[0]).split(':')
+            username, password = b64decode(split[0]).split(':', 1)
         except:
             raise DecodeError
 
@@ -37,7 +37,7 @@ def decode(encoded_str):
     elif len(split) == 2:
         if split[0].strip().lower() == 'basic':
             try:
-                username, password = b64decode(split[1]).split(':')
+                username, password = b64decode(split[1]).split(':', 1)
             except:
                 raise DecodeError
         else:

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from basicauth import decode, DecodeError, encode
+from base64 import b64encode
 
 
 class Encode(TestCase):
@@ -55,6 +56,7 @@ class Decode(TestCase):
         self.assertRaises(DecodeError, decode, encoded_str)
 
     def test_properly_escapes_colons(self):
-        username, password = 'user:name:', 'pass:word:'
-        encoded_str = encode(username, password)
+        username, password = 'username', 'pass:word:'
+        # client may not have been encoded the way this lib does it
+        encoded_str = 'Basic %s' % b64encode('%s:%s' % (username, password))
         self.assertEqual((username, password), decode(encoded_str))


### PR DESCRIPTION
Fixes the problem described in issue #1. I don't like that this doesn't handle a username with a colon in it, but I can't think of a good way to handle it - from my testing common HTTP clients happily base64 colon into the username and password strings without any kind of HTTP encoding, I don't think there's anything to do but split on the first occurrence of colon :boom: 
