### PR TITLE
Prevent colon character in username

### DIFF
--- a/basicauth.py
+++ b/basicauth.py
@@ -9,10 +9,17 @@ class DecodeError(Exception):
     pass
 
 
+class EncodeError(Exception):
+    pass
+
+
 def encode(username, password):
     """Returns an HTTP basic authentication encrypted string given a valid
     username and password.
     """
+    if ':' in username:
+        raise EncodeError
+
     username_password = '%s:%s' % (quote(username), quote(password))
     return 'Basic ' + b64encode(username_password.encode()).decode()
 

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,7 @@
 from base64 import b64encode
 from unittest import TestCase
 
-from basicauth import decode, DecodeError, encode
+from basicauth import decode, DecodeError, encode, EncodeError
 
 
 class Encode(TestCase):
@@ -23,6 +23,9 @@ class Encode(TestCase):
 
     def test_encodes_long_password(self):
         self.assertTrue(encode('', 'password'*1000000))
+
+    def test_prevent_colon_char(self):
+        self.assertRaises(EncodeError, lambda: encode(':', 'password'))
 
 
 class Decode(TestCase):


### PR DESCRIPTION
As wrote in rfc: username can not contains colon character.