### PR TITLE
TravisCI: Move to testing Python 2.7 only and 3.5-9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.8"
+  - "3.7"
+  - "3.9"
 install:
   - python setup.py develop
   - pip install -r requirements.txt


### PR DESCRIPTION
- Was looking to use this module just to save re-inventing the function
- See if tests pass on newer Pythons first